### PR TITLE
Fix: rename cookie - acceptedIntercom -> acceptedSupportAndUpdates

### DIFF
--- a/src/utils/CookiesBanner.tsx
+++ b/src/utils/CookiesBanner.tsx
@@ -157,17 +157,17 @@ const CookiesBanner = () => {
       const cookiesState: CookiesProps = await loadFromCookie(COOKIES_KEY)
       if (cookiesState) {
         const {
-          acceptedIntercom,
+          acceptedSupportAndUpdates,
           acceptedAnalytics,
           acceptedNecessary,
         } = cookiesState
         setLocalAnalytics(acceptedAnalytics)
-        setLocalIntercom(acceptedIntercom)
+        setLocalIntercom(acceptedSupportAndUpdates)
         setLocalNecessary(acceptedNecessary)
         const openBanner = acceptedNecessary === false || showBanner
         openCookieBanner(openBanner)
         setShowAnalytics(acceptedAnalytics)
-        setShowIntercom(acceptedIntercom)
+        setShowIntercom(acceptedSupportAndUpdates)
       } else {
         openCookieBanner(true)
       }
@@ -180,7 +180,7 @@ const CookiesBanner = () => {
     const newState = {
       acceptedNecessary: true,
       acceptedAnalytics: true,
-      acceptedIntercom: true,
+      acceptedSupportAndUpdates: true,
     }
     const cookieConfig: CookieAttributes = {
       expires: 365,
@@ -196,7 +196,7 @@ const CookiesBanner = () => {
     const newState = {
       acceptedNecessary: true,
       acceptedAnalytics: localAnalytics,
-      acceptedIntercom: localIntercom,
+      acceptedSupportAndUpdates: localIntercom,
     }
     const cookieConfig: CookieAttributes = {
       expires: localAnalytics ? 365 : 7,

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -6,7 +6,7 @@ export const COOKIES_KEY_INTERCOM = `${COOKIES_KEY}_INTERCOM`
 export type CookiesProps = {
   acceptedNecessary: boolean
   acceptedAnalytics: boolean
-  acceptedIntercom: boolean
+  acceptedSupportAndUpdates: boolean
   cookieBannerOpen: boolean
 }
 


### PR DESCRIPTION
To match the naming in safe-react: [BannerCookiesType](https://github.com/gnosis/safe-react/blob/3f1134efb4a0eabc9166c5cefdf8e599e5abd2f3/src/logic/cookies/model/cookie.ts#L16)

Introduced in https://github.com/gnosis/safe-react/pull/3515.