### PR TITLE
Fix: cookie banner text

### DIFF
--- a/src/utils/CookiesBanner.tsx
+++ b/src/utils/CookiesBanner.tsx
@@ -250,8 +250,8 @@ const CookiesBanner = () => {
             <FormItem>
               <FormControlLabel
                 control={<SCheckbox checked={localIntercom} />}
-                label="Customer support"
-                name="Customer support"
+                label="Community support & updates"
+                name="Community support & updates"
                 onChange={() => setLocalIntercom((prev) => !prev)}
                 value={localIntercom}
               />


### PR DESCRIPTION
A small edit of the cookie banner copy.

<img width="290" alt="Screenshot 2022-03-10 at 17 48 38" src="https://user-images.githubusercontent.com/381895/157713121-d163bda0-a328-4091-b545-a58894f1b5cf.png">
