### PR TITLE
feat: Add header section for careers page

### DIFF
--- a/src/components/careers/Header/index.tsx
+++ b/src/components/careers/Header/index.tsx
@@ -95,9 +95,11 @@ const Header = ({ openPositions }: { openPositions: number | undefined }) => {
       <Wrapper>
         <ContentWrapper>
           <div>
-            <Grid item xs={12}>
-              <Text>{openPositions} Positions</Text>
-            </Grid>
+            {openPositions && (
+              <Grid item xs={12}>
+                <Text>{openPositions} Positions</Text>
+              </Grid>
+            )}
             <Grid container alignItems="center">
               <Grid item xs={12} md={6}>
                 <Title>

--- a/src/components/careers/Header/index.tsx
+++ b/src/components/careers/Header/index.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Box, Grid } from '@material-ui/core'
+
+import LinesSVG from '../../../assets/bg-lines-03.svg'
+import ContentWrapper from '../../Layout/ContentWrapper'
+
+const Container = styled.main`
+  height: calc(100vh - 56px);
+  position: relative;
+  padding: 0 20px;
+  background-color: ${(p) => p.theme.palette.navy};
+
+  @media screen and (max-width: 980px) {
+    height: auto;
+    padding: 0 16px;
+  }
+`
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  height: 100%;
+  color: white;
+  position: relative;
+  z-index: 2;
+
+  @media screen and (max-width: 980px) {
+    padding-top: 135px;
+    padding-bottom: 65px;
+  }
+`
+
+const SLinesSVG = styled(LinesSVG)`
+  position: absolute;
+  left: 0;
+  bottom: -100px;
+  stroke: #d8d8d8;
+  opacity: 0.27;
+  z-index: 1;
+
+  @media screen and (max-width: 980px) {
+    bottom: -50px;
+  }
+`
+
+const Title = styled.h1`
+  font-size: 60px;
+  line-height: 65px;
+  color: white;
+  font-weight: bolder;
+  margin-top: 16px;
+  margin-bottom: 45px;
+
+  @media screen and (max-width: 980px) {
+    margin-bottom: 16px;
+  }
+`
+
+const Text = styled.p`
+  font-size: 20px;
+  line-height: 26px;
+`
+
+const FeatureText = styled.p`
+  font-size: 24px;
+  line-height: 32px;
+
+  @media screen and (max-width: 980px) {
+    margin-bottom: 40px;
+  }
+`
+
+const AnchorLink = styled.a`
+  font-size: 16px;
+  line-height: 22px;
+  color: white;
+  font-weight: bold;
+  background-color: ${(p) => p.theme.palette.primary};
+  padding: 15px 24px;
+  border-radius: 8px;
+  text-decoration: none;
+  display: inline-block;
+
+  &:hover {
+    background-color: ${(p) => p.theme.palette.primaryHover};
+  }
+`
+
+const Header = ({ openPositions }: { openPositions: number | undefined }) => {
+  return (
+    <Container>
+      <SLinesSVG />
+      <Wrapper>
+        <ContentWrapper>
+          <div>
+            <Grid item xs={12}>
+              <Text>{openPositions} Positions</Text>
+            </Grid>
+            <Grid container alignItems="center">
+              <Grid item xs={12} md={6}>
+                <Title>
+                  Join us
+                  <br />
+                  at Gnosis
+                </Title>
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <FeatureText>
+                  By designing fairer markets, we aim to build a more evenly
+                  distributed future, together. Be a part of a team building
+                  leading decentralized finance products.
+                </FeatureText>
+              </Grid>
+            </Grid>
+            <Grid item xs={12}>
+              <AnchorLink href="#positions">Explore positions</AnchorLink>
+            </Grid>
+          </div>
+        </ContentWrapper>
+      </Wrapper>
+    </Container>
+  )
+}
+
+export default Header

--- a/src/components/careers/Positions/index.tsx
+++ b/src/components/careers/Positions/index.tsx
@@ -53,12 +53,10 @@ export type Jobs = {
   }
 }
 
-const Positions = () => {
-  const positions = usePositions()
-
+const Positions = ({ positions }: { positions: Job[] | undefined }) => {
   return (
     <ContentWrapper>
-      <SectionTitle>Open positions</SectionTitle>
+      <SectionTitle id="positions">Open positions</SectionTitle>
       {!positions ? (
         <Text>
           Unfortunately, there are <strong>no positions available</strong> at
@@ -67,7 +65,7 @@ const Positions = () => {
         </Text>
       ) : (
         <Grid container spacing={3}>
-          {positions.jobs.map((job) => {
+          {positions.map((job) => {
             return (
               <Grid key={job.id} item xs={12} sm={6} md={4}>
                 <Card

--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -1,18 +1,25 @@
 import * as React from 'react'
 
 import Layout from '../components/Layout'
+import Header from '../components/careers/Header'
 import Benefits from '../components/careers/Benefits'
 import Leadership from '../components/careers/Leadership'
 import Positions from '../components/careers/Positions'
 import Locations from '../components/careers/Locations'
 import InitiativeApplication from '../components/careers/InitiativeApplication'
+import { usePositions } from '../components/careers/Positions/usePositions'
 
-export default () => (
-  <Layout title="Careers">
-    <Benefits />
-    <Leadership />
-    <Positions />
-    <InitiativeApplication />
-    <Locations />
-  </Layout>
-)
+export default () => {
+  const positions = usePositions()
+
+  return (
+    <Layout title="Careers">
+      <Header openPositions={positions?.meta.total} />
+      <Benefits />
+      <Leadership />
+      <Positions positions={positions?.jobs} />
+      <InitiativeApplication />
+      <Locations />
+    </Layout>
+  )
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,17 @@
   src: url('/fonts/Averta-ExtraBold.woff2') format('woff2');
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+
 body {
   -webkit-font-smoothing: antialiased;
   min-height: 100%;


### PR DESCRIPTION
## What it solves

Adds a header section to the careers page

## Screenshot
![Screenshot 2022-04-27 at 12 50 29](https://user-images.githubusercontent.com/5880855/165502386-b02e0a57-3359-48d5-9056-5b59e86a7103.png)

